### PR TITLE
Support s3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v1.5.1
+    - Support S3 Compatibility(e.g. ECS)
 # v1.5.0
     - Preview File button
 

--- a/src/aws-sdk/parseKnownFiles.ts
+++ b/src/aws-sdk/parseKnownFiles.ts
@@ -17,8 +17,12 @@ export interface SourceProfileInit extends SharedConfigInit {
  */
 export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
   const parsedFiles = await loadSharedConfigFiles(init);
-  return {
-    ...parsedFiles.configFile,
-    ...parsedFiles.credentialsFile,
-  };
+  let returnProfile: { [key: string]: any } = {}; // Add index signature
+  if (init !== undefined && init.profile !== undefined) {
+    var name = init.profile;
+    returnProfile[name] = { ...parsedFiles.configFile[name], ...parsedFiles.credentialsFile[name] }; // Remove extra closing brace
+  }
+  else{
+  returnProfile = { ...parsedFiles.configFile, ...parsedFiles.credentialsFile };}
+  return returnProfile;
 };

--- a/src/common/API.ts
+++ b/src/common/API.ts
@@ -88,7 +88,7 @@ function GetS3Client() {
 
   let credentials = GetCredentials();
   s3 = new AWS.S3({ credentials: credentials, endpoint:S3TreeView.S3TreeView.Current?.AwsEndPoint});
-  
+  s3.config.s3ForcePathStyle = S3TreeView.S3TreeView.Current?.Addressing_style;
   return s3;
 }
 

--- a/src/common/API.ts
+++ b/src/common/API.ts
@@ -10,7 +10,6 @@ import { ParsedIniData } from "@aws-sdk/types";
 import * as s3_helper from '../s3/S3Helper'
 import * as fs from 'fs';
 import * as S3TreeView from '../s3/S3TreeView';
-import { error } from "console";
 
 export function IsSharedIniFileCredentials(credentials:any|undefined=undefined)
 {
@@ -589,6 +588,27 @@ export async function getIniProfileData(init: SourceProfileInit = {}):Promise<Pa
 {
     const profiles = await parseKnownFiles(init);
     return profiles;
+}
+
+export function getPresignedUrl(Bucket:string,Key:string): string {
+  try 
+  {
+    const s3 = GetS3Client();
+
+    let param = {
+      Bucket:Bucket,
+      Key:Key
+    }
+
+    let response = s3.getSignedUrl('getObject', param);
+    return response;
+  } 
+  catch (error:any) 
+  {
+    ui.showErrorMessage('api.getPresignedUrl Error !!!', error);
+    ui.logToOutput("api.getPresignedUrl Error !!!", error); 
+    return error.message;
+  }
 }
 
 export const ENV_CREDENTIALS_PATH = "AWS_SHARED_CREDENTIALS_FILE";

--- a/src/common/ProfileConfig.ts
+++ b/src/common/ProfileConfig.ts
@@ -1,0 +1,83 @@
+export interface ProfileConfig {
+    filterString:string,
+    addressing_style:boolean,
+    awsProfile:string|undefined,
+    awsEndPoint:string|undefined,
+    bucketList:string[]|undefined,
+    shortcutList:[[string,string]]|undefined,
+}
+
+export class ProfileConfigRepository {
+    private static instance: ProfileConfigRepository;
+    private configs: ProfileConfig[] =[];
+    private constructor() {}
+    public static getInstance(): ProfileConfigRepository {
+        if (!ProfileConfigRepository.instance) {
+            ProfileConfigRepository.instance = new ProfileConfigRepository();
+        }
+        return ProfileConfigRepository.instance;
+    }
+    public getProfileConfig(awsprofile?:string): ProfileConfig {
+        var retConfig=undefined;
+        if(awsprofile)
+        {
+            this.configs.forEach((config)=>{
+                if(config.awsProfile===awsprofile)
+                {
+                    retConfig=config;
+                    return;
+                }
+            });
+        }
+        if(!retConfig) 
+        {
+            retConfig={
+                filterString:"",
+                addressing_style:false,
+                awsProfile:undefined,
+                awsEndPoint:undefined,
+                bucketList:undefined,
+                shortcutList:undefined,
+            }
+        }
+        return retConfig;
+    }
+
+    public setProfileConfig(config: ProfileConfig): void {
+        console.log(config);
+        if(config.awsProfile)
+        {
+            var needNewConfig=true;
+            this.configs.forEach((conf)=>{
+                if(conf.awsProfile===config.awsProfile)
+                {
+                    conf=config;
+                    needNewConfig=false;
+                    console.log("profile config updated");
+                    return;
+                }
+            });
+            if(needNewConfig)
+            {
+                this.configs.push(config);
+                console.log("profile config added");
+            }
+        }
+        else
+        {
+            console.log("awsProfile is undefined");
+        }
+    }
+
+    public getProfileConfigList(): ProfileConfig[] {
+        return this.configs;
+    }
+
+    public serialize(): string {
+        return JSON.stringify(this.configs);
+    }
+
+    public deserialize(configs: string): void {
+        this.configs = JSON.parse(configs);
+    }
+}

--- a/src/s3/S3Helper.ts
+++ b/src/s3/S3Helper.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
-
+import * as api from "../common/API";
+import { log } from "console";
 export function IsRoot(Key:string):boolean
 {
     return Key === "";
@@ -34,12 +35,12 @@ export function GetFullPath(Bucket:string, Key:string):string
 
 export function GetURI(Bucket:string, Key:string):string
 {
-    return "s3://" + GetFullPath(Bucket, Key);
+    return "s3a://" + GetFullPath(Bucket, Key);
 }
 
 export function GetURL(Bucket:string, Key:string):string
 {
-    return "https://" + Bucket + ".s3.amazonaws.com/" + Key;
+    return api.getPresignedUrl(Bucket, Key);
 }
 
 export function GetARN(Bucket:string, Key:string)

--- a/src/s3/S3TreeView.ts
+++ b/src/s3/S3TreeView.ts
@@ -4,9 +4,9 @@ import { S3TreeItem, TreeItemType } from './S3TreeItem';
 import { S3TreeDataProvider } from './S3TreeDataProvider';
 import * as ui from '../common/UI';
 import * as api from '../common/API';
-import { APIGateway } from 'aws-sdk';
 import { S3Explorer } from './S3Explorer';
 import { S3Search } from './S3Search';
+import { ProfileConfig, ProfileConfigRepository } from '../common/ProfileConfig';
 
 export class S3TreeView {
 
@@ -17,13 +17,15 @@ export class S3TreeView {
 	public FilterString: string = "";
 	public isShowOnlyFavorite: boolean = false;
 	public isShowHiddenNodes: boolean = false;
-    public Addressing_style: boolean = false;
-	public AwsProfile: string = "default";	
+	public Addressing_style: boolean = false;
+	public AwsProfile: string = "default";
 	public AwsEndPoint: string | undefined;
+	private profileConfig: ProfileConfig;
 
 	constructor(context: vscode.ExtensionContext) {
 		ui.logToOutput('TreeView.constructor Started');
 		this.context = context;
+		this.profileConfig = ProfileConfigRepository.getInstance().getProfileConfig();
 		this.treeDataProvider = new S3TreeDataProvider();
 		this.LoadState();
 		this.view = vscode.window.createTreeView('S3TreeView', { treeDataProvider: this.treeDataProvider, showCollapseAll: true });
@@ -34,7 +36,7 @@ export class S3TreeView {
 		this.TestAwsConnection();
 	}
 
-	TestAwsConnection(){
+	TestAwsConnection() {
 		api.TestAwsConnection()
 	}
 
@@ -53,7 +55,7 @@ export class S3TreeView {
 		});
 	}
 
-	LoadTreeItems(){
+	LoadTreeItems() {
 		ui.logToOutput('S3TreeView.loadTreeItems Started');
 
 		//this.treeDataProvider.LoadRegionNodeList();
@@ -126,24 +128,29 @@ export class S3TreeView {
 		this.SaveState();
 	}
 
-	async SetViewTitle(){
+	async SetViewTitle() {
 		this.view.title = "Aws S3";
 	}
 
-	SaveState() {
+	SaveState(initProfile?:boolean) {
 		ui.logToOutput('S3TreeView.saveState Started');
 		try {
 
 			this.context.globalState.update('AwsProfile', this.AwsProfile);
-			this.context.globalState.update('FilterString', this.FilterString);
-			this.context.globalState.update('ShowOnlyFavorite', this.isShowOnlyFavorite);
-			this.context.globalState.update('ShowHiddenNodes', this.isShowHiddenNodes);
-			this.context.globalState.update('BucketList', this.treeDataProvider.GetBucketList());
-			this.context.globalState.update('ShortcutList', this.treeDataProvider.GetShortcutList());
-			this.context.globalState.update('ViewType', this.treeDataProvider.ViewType);
-			this.context.globalState.update('AwsEndPoint', this.AwsEndPoint);
-			this.context.globalState.update('Addressing_style', this.Addressing_style);
 
+			this.context.globalState.update('ViewType', this.treeDataProvider.ViewType);
+			this.profileConfig=ProfileConfigRepository.getInstance().getProfileConfig(this.AwsProfile);
+			this.profileConfig.addressing_style= this.Addressing_style;
+			this.profileConfig.awsEndPoint=this.AwsEndPoint;
+			this.profileConfig.awsProfile=this.AwsProfile;
+			if(initProfile==undefined || !initProfile)
+			{
+				this.profileConfig.filterString=this.FilterString;
+				this.profileConfig.bucketList = this.treeDataProvider.GetBucketList();
+				this.profileConfig.shortcutList = this.treeDataProvider.GetShortcutList();
+			}
+			ProfileConfigRepository.getInstance().setProfileConfig(this.profileConfig);
+			this.context.globalState.update("profileConfigs", ProfileConfigRepository.getInstance().serialize());
 			ui.logToOutput("S3TreeView.saveState Successfull");
 		} catch (error) {
 			ui.logToOutput("S3TreeView.saveState Error !!!");
@@ -159,86 +166,74 @@ export class S3TreeView {
 				this.AwsProfile = AwsProfileTemp;
 			}
 
-			let filterStringTemp: string | undefined = this.context.globalState.get('FilterString');
-			if (filterStringTemp) {
-				this.FilterString = filterStringTemp;
-			}
-
-			let ShowOnlyFavoriteTemp: boolean | undefined = this.context.globalState.get('ShowOnlyFavorite');
-			if (ShowOnlyFavoriteTemp) { this.isShowOnlyFavorite = ShowOnlyFavoriteTemp; }
-
-			let ShowHiddenNodesTemp: boolean | undefined = this.context.globalState.get('ShowHiddenNodes');
-			if (ShowHiddenNodesTemp) { this.isShowHiddenNodes = ShowHiddenNodesTemp; }
-
-			let BucketListTemp:string[] | undefined  = this.context.globalState.get('BucketList');
-			if(BucketListTemp)
-			{
-				this.treeDataProvider.SetBucketList(BucketListTemp);
-			}
-
-			let ShortcutListTemp:[[string,string]] | undefined  = this.context.globalState.get('ShortcutList');
-			if(ShortcutListTemp)
-			{
-				this.treeDataProvider.SetShortcutList(ShortcutListTemp);
-			}
-
-			let ViewTypeTemp:number | undefined = this.context.globalState.get('ViewType');
-			if(ViewTypeTemp)
-			{
+			let ViewTypeTemp: number | undefined = this.context.globalState.get('ViewType');
+			if (ViewTypeTemp) {
 				this.treeDataProvider.ViewType = ViewTypeTemp;
 			}
 
-			let AwsEndPointTemp: string | undefined = this.context.globalState.get('AwsEndPoint');
-			this.AwsEndPoint = AwsEndPointTemp;
-
-			let Addressing_styleTemp: boolean | undefined = this.context.globalState.get('Addressing_style');
-			if(Addressing_styleTemp)
-			{
-				this.Addressing_style=Addressing_styleTemp;
+			let profileConfigsTemp: string | undefined = this.context.globalState.get('profileConfigs');
+			if (profileConfigsTemp) {
+				ProfileConfigRepository.getInstance().deserialize(profileConfigsTemp);
+				this.profileConfig = ProfileConfigRepository.getInstance().getProfileConfig(this.AwsProfile);
+				if (this.profileConfig) {
+					this.FilterString = this.profileConfig.filterString;
+					this.Addressing_style = this.profileConfig.addressing_style;
+					this.AwsEndPoint = this.profileConfig.awsEndPoint;
+					let BucketListTemp: string[] | undefined = this.profileConfig.bucketList;
+					if (BucketListTemp) {
+						this.treeDataProvider.SetBucketList(BucketListTemp);
+					}
+					else{
+						this.treeDataProvider.SetBucketList([]);
+					}
+					let ShortcutListTemp: [[string, string]] | undefined = this.profileConfig.shortcutList;
+					if (ShortcutListTemp) {
+						this.treeDataProvider.SetShortcutList(ShortcutListTemp);
+					}
+					else{
+						this.treeDataProvider.SetShortcutList([["???","???"]]);
+					}
+				}
 			}
 			ui.logToOutput("S3TreeView.loadState Successfull");
-
-		} 
-		catch (error) 
-		{
+		}
+		catch (error) {
 			ui.logToOutput("S3TreeView.loadState Error !!!");
 		}
 	}
 
-	SetFilterMessage(){
-		this.view.message = 
-		this.GetFilterProfilePrompt()
-		+ this.GetBoolenSign(this.isShowOnlyFavorite) + "Fav, " 
-		+ this.GetBoolenSign(this.isShowHiddenNodes) + "Hidden, "
-		+ this.FilterString;
+	SetFilterMessage() {
+		this.view.message =
+			this.GetFilterProfilePrompt()
+			+ this.GetBoolenSign(this.isShowOnlyFavorite) + "Fav, "
+			+ this.GetBoolenSign(this.isShowHiddenNodes) + "Hidden, "
+			+ this.FilterString;
 	}
 
 	private GetFilterProfilePrompt() {
-		if(api.IsSharedIniFileCredentials())
-		{
+		if (api.IsSharedIniFileCredentials()) {
 			return "Profile:" + this.AwsProfile + " ";
 		}
 		return ""
 	}
 
-	GetBoolenSign(variable: boolean){
+	GetBoolenSign(variable: boolean) {
 		return variable ? "✓" : "𐄂";
 	}
 
-	async AddBucket(){
+	async AddBucket() {
 		ui.logToOutput('S3TreeView.AddBucket Started');
 
 		let selectedBucketName = await vscode.window.showInputBox({ placeHolder: 'Enter Bucket Name / Search Text' });
-		if(selectedBucketName===undefined){ return; }
+		if (selectedBucketName === undefined) { return; }
 
 		var resultBucket = await api.GetBucketList(selectedBucketName);
-		if(!resultBucket.isSuccessful){ return; }
+		if (!resultBucket.isSuccessful) { return; }
 
-		let selectedBucketList = await vscode.window.showQuickPick(resultBucket.result, {canPickMany:true, placeHolder: 'Select Bucket(s)'});
-		if(!selectedBucketList || selectedBucketList.length===0){ return; }
+		let selectedBucketList = await vscode.window.showQuickPick(resultBucket.result, { canPickMany: true, placeHolder: 'Select Bucket(s)' });
+		if (!selectedBucketList || selectedBucketList.length === 0) { return; }
 
-		for(var selectedBucket of selectedBucketList)
-		{
+		for (var selectedBucket of selectedBucketList) {
 			this.treeDataProvider.AddBucket(selectedBucket);
 		}
 		this.SaveState();
@@ -246,74 +241,70 @@ export class S3TreeView {
 
 	async RemoveBucket(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.RemoveBucket Started');
-		
-		if(node.TreeItemType !== TreeItemType.Bucket) { return;}
-		if(!node.Bucket) { return; }
 
-		this.treeDataProvider.RemoveBucket(node.Bucket);		
+		if (node.TreeItemType !== TreeItemType.Bucket) { return; }
+		if (!node.Bucket) { return; }
+
+		this.treeDataProvider.RemoveBucket(node.Bucket);
 		this.SaveState();
 	}
 
 	async Goto(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.Goto Started');
-		
-		if(node.TreeItemType !== TreeItemType.Bucket) { return;}
-		if(!node.Bucket) { return; }
+
+		if (node.TreeItemType !== TreeItemType.Bucket) { return; }
+		if (!node.Bucket) { return; }
 
 		let shortcut = await vscode.window.showInputBox({ placeHolder: 'Enter a Folder/File Key' });
-		if(shortcut===undefined){ return; }
-		
+		if (shortcut === undefined) { return; }
+
 		S3Explorer.Render(this.context.extensionUri, node, shortcut);
 	}
 
-	async AddOrRemoveShortcut(Bucket:string, Key:string) {
+	async AddOrRemoveShortcut(Bucket: string, Key: string) {
 		ui.logToOutput('S3TreeView.AddOrRemoveShortcut Started');
-		if(!Bucket || !Key) { return; }
-		
-		if(this.treeDataProvider.DoesShortcutExists(Bucket, Key))
-		{
+		if (!Bucket || !Key) { return; }
+
+		if (this.treeDataProvider.DoesShortcutExists(Bucket, Key)) {
 			this.treeDataProvider.RemoveShortcut(Bucket, Key);
 		}
-		else
-		{
+		else {
 			this.treeDataProvider.AddShortcut(Bucket, Key);
 		}
-		
+
 		this.SaveState();
 	}
 
-	async RemoveShortcutByKey(Bucket:string, Key:string) {
+	async RemoveShortcutByKey(Bucket: string, Key: string) {
 		ui.logToOutput('S3TreeView.RemoveShortcutByKey Started');
-		if(!Bucket || !Key) { return; }
-		
-		if(this.treeDataProvider.DoesShortcutExists(Bucket, Key))
-		{
+		if (!Bucket || !Key) { return; }
+
+		if (this.treeDataProvider.DoesShortcutExists(Bucket, Key)) {
 			this.treeDataProvider.RemoveShortcut(Bucket, Key);
 			this.SaveState();
 		}
 	}
 
-	async UpdateShortcutByKey(Bucket:string, Key:string, NewKey:string) {
+	async UpdateShortcutByKey(Bucket: string, Key: string, NewKey: string) {
 		ui.logToOutput('S3TreeView.RemoveShortcutByKey Started');
-		if(!Bucket || !Key) { return; }
-		
-		if(this.treeDataProvider.DoesShortcutExists(Bucket, Key))
-		{
+		if (!Bucket || !Key) { return; }
+
+		if (this.treeDataProvider.DoesShortcutExists(Bucket, Key)) {
 			this.treeDataProvider.UpdateShortcut(Bucket, Key, NewKey);
 			this.SaveState();
 		}
 	}
 
-	DoesShortcutExists(Bucket:string, Key:string|undefined):boolean {
-		if(!Key){return false;}
+	DoesShortcutExists(Bucket: string, Key: string | undefined): boolean {
+		if (!Key) { return false; }
 		return this.treeDataProvider.DoesShortcutExists(Bucket, Key);
 	}
 
 	async RemoveShortcut(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.RemoveShortcut Started');
-		if(node.TreeItemType !== TreeItemType.Shortcut) { return;}
-		if(!node.Bucket || !node.Shortcut) { return; }
-		
+		if (node.TreeItemType !== TreeItemType.Shortcut) { return; }
+		if (!node.Bucket || !node.Shortcut) { return; }
+
 		this.treeDataProvider.RemoveShortcut(node.Bucket, node.Shortcut);
 		S3Explorer.Current?.RenderHtml();//to update shortcut icon
 		this.SaveState();
@@ -321,34 +312,34 @@ export class S3TreeView {
 
 	async CopyShortcut(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.CopyShortcut Started');
-		if(node.TreeItemType !== TreeItemType.Shortcut) { return;}
-		if(!node.Bucket || !node.Shortcut) { return; }
-		
+		if (node.TreeItemType !== TreeItemType.Shortcut) { return; }
+		if (!node.Bucket || !node.Shortcut) { return; }
+
 		vscode.env.clipboard.writeText(node.Shortcut)
 	}
 
 	async AddShortcut(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.AddShortcut Started');
-		if(!node.Bucket) { return; }
-		
+		if (!node.Bucket) { return; }
+
 		let bucket = node.Bucket
 
 		let shortcut = await vscode.window.showInputBox({ placeHolder: 'Enter a Folder/File Key' });
-		if(shortcut===undefined){ return; }
-		
+		if (shortcut === undefined) { return; }
+
 		this.AddOrRemoveShortcut(bucket, shortcut)
 	}
 
 	async ShowS3Explorer(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.ShowS3Explorer Started');
-		
+
 
 		S3Explorer.Render(this.context.extensionUri, node);
 	}
 
 	async ShowS3Search(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.ShowS3Search Started');
-		
+
 
 		S3Search.Render(this.context.extensionUri, node);
 	}
@@ -356,24 +347,26 @@ export class S3TreeView {
 	async SelectAwsProfile(node: S3TreeItem) {
 		ui.logToOutput('S3TreeView.SelectAwsProfile Started');
 
-		if (!api.IsSharedIniFileCredentials())
-		{
+		if (!api.IsSharedIniFileCredentials()) {
 			ui.showWarningMessage("Your Aws Access method is not credentials file");
 			return;
 		}
 
 		var result = await api.GetAwsProfileList();
-		if(!result.isSuccessful){ return; }
+		if (!result.isSuccessful) { return; }
 
-		let selectedAwsProfile = await vscode.window.showQuickPick(result.result, {canPickMany:false, placeHolder: 'Select Aws Profile'});
-		if(!selectedAwsProfile){ return; }
+		let selectedAwsProfile = await vscode.window.showQuickPick(result.result, { canPickMany: false, placeHolder: 'Select Aws Profile' });
+		if (!selectedAwsProfile) { return; }
 
 		this.AwsProfile = selectedAwsProfile;
 
-		var selectedConfigs = await api.getIniProfileData({profile:this.AwsProfile});
+		var selectedConfigs = await api.getIniProfileData({ profile: this.AwsProfile });
 		this.AwsEndPoint = selectedConfigs[this.AwsProfile].endpoint_url;
-		this.Addressing_style = selectedConfigs[this.AwsProfile].addressing_style==="false"?false:true;
-		this.SaveState();
+		this.Addressing_style = selectedConfigs[this.AwsProfile].addressing_style === "false" ? false : true;
+		this.SaveState(true);
+		//refresh the proflie config when the aws profile is changed.
+		this.LoadState();
+		this.ResetView();
 		this.SetFilterMessage();
 		this.TestAwsConnection();
 	}
@@ -382,10 +375,9 @@ export class S3TreeView {
 		ui.logToOutput('S3TreeView.UpdateAwsEndPoint Started');
 
 		let awsEndPointUrl = await vscode.window.showInputBox({ placeHolder: 'Enter Aws End Point URL (Leave Empty To Return To Default)' });
-		if(awsEndPointUrl===undefined){ return; }
-		if(awsEndPointUrl.length===0) { this.AwsEndPoint = undefined; }
-		else
-		{
+		if (awsEndPointUrl === undefined) { return; }
+		if (awsEndPointUrl.length === 0) { this.AwsEndPoint = undefined; }
+		else {
 			this.AwsEndPoint = awsEndPointUrl;
 		}
 		this.SaveState();

--- a/src/s3/S3TreeView.ts
+++ b/src/s3/S3TreeView.ts
@@ -17,6 +17,7 @@ export class S3TreeView {
 	public FilterString: string = "";
 	public isShowOnlyFavorite: boolean = false;
 	public isShowHiddenNodes: boolean = false;
+    public Addressing_style: boolean = false;
 	public AwsProfile: string = "default";	
 	public AwsEndPoint: string | undefined;
 
@@ -141,6 +142,7 @@ export class S3TreeView {
 			this.context.globalState.update('ShortcutList', this.treeDataProvider.GetShortcutList());
 			this.context.globalState.update('ViewType', this.treeDataProvider.ViewType);
 			this.context.globalState.update('AwsEndPoint', this.AwsEndPoint);
+			this.context.globalState.update('Addressing_style', this.Addressing_style);
 
 			ui.logToOutput("S3TreeView.saveState Successfull");
 		} catch (error) {
@@ -189,6 +191,11 @@ export class S3TreeView {
 			let AwsEndPointTemp: string | undefined = this.context.globalState.get('AwsEndPoint');
 			this.AwsEndPoint = AwsEndPointTemp;
 
+			let Addressing_styleTemp: boolean | undefined = this.context.globalState.get('Addressing_style');
+			if(Addressing_styleTemp)
+			{
+				this.Addressing_style=Addressing_styleTemp;
+			}
 			ui.logToOutput("S3TreeView.loadState Successfull");
 
 		} 
@@ -362,6 +369,10 @@ export class S3TreeView {
 		if(!selectedAwsProfile){ return; }
 
 		this.AwsProfile = selectedAwsProfile;
+
+		var selectedConfigs = await api.getIniProfileData({profile:this.AwsProfile});
+		this.AwsEndPoint = selectedConfigs[this.AwsProfile].endpoint_url;
+		this.Addressing_style = selectedConfigs[this.AwsProfile].addressing_style==="false"?false:true;
 		this.SaveState();
 		this.SetFilterMessage();
 		this.TestAwsConnection();


### PR DESCRIPTION
I've fixed the issue that cannot load the configuration from config file and added the following features:
1. support to access s3 compatibility storage. (e.g. ECS)
2. save the cache data against the profile to access the buckets convenience by different AWS profile.
3. provide presigned url to access s3 object instead the URL.

 Hope these changes will be merged into main branch. 